### PR TITLE
limit gazette layout content width to 8 columns for readability

### DIFF
--- a/_includes/layouts/bluehats-post.njk
+++ b/_includes/layouts/bluehats-post.njk
@@ -30,7 +30,11 @@ layout: layouts/base.njk
         </p>
       {% endif %}
 
-      {{ content | safe }}
+      <div class="fr-grid-row">
+        <div class="fr-col-md-8">
+          {{ content | safe }}
+        </div>
+      </div>
 
       {% if video %}
         <figure class="fr-content-media" role="group">


### PR DESCRIPTION
👋 hello ! Je suggère de réduire la largeur maximum du contenu des pages de gazette.

Il est en effet indiqué en bas de la page https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-de-l-identite-de-l-etat/typographie/ :

> Il est recommandé de veiller à limiter le nombre de caractère par ligne. Nous vous recommandons d’utiliser un conteneur de maximum 8 colonnes pour les contenus.

Aperçu sur FF desktop :

![image](https://github.com/codegouvfr/codegouvfr-website/assets/883348/1b831edf-4622-47cf-91d4-6501a7181b26)

